### PR TITLE
libunwind code movaps xmm, 0xxx0(rsp) is causing misaligned exception

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,7 @@ fn compile_libunwind() {
     cfg.flag("-fstrict-aliasing");
     cfg.flag("-fvisibility=hidden");
     cfg.flag("-funwind-tables");
+    cfg.flag("-mpreferred-stack-boundary=3");
     cfg.define("_LIBUNWIND_NO_HEAP", None);
     cfg.define("_LIBUNWIND_IS_BAREMETAL", None);
     cfg.define("_LIBUNWIND_IS_NATIVE_ONLY", None);


### PR DESCRIPTION
libunwind code movaps xmm, 0xxx0(rsp) is causing misaligned exception
but compiler default is 16 byte aligned.
align stack boundary to 8 bytes
default it aligns to 16, but somehow rsp is not 16 byte aligned, it caused movaps access misaligned(8 bytes not 16 bytes) address.

need to see why rsp is not aligned by 16